### PR TITLE
商品一覧表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Things you may want to cover:
 ### Association
 
 - belongs_to :user
-- belongs_to : item
+- belongs_to :item
 
 ### addresses テーブル
 
-| Column  | Type       | Options                        |
+| Column  | Type      | Options                        |
 | ------- | ---------- | ------------------------------ |
 | post_code    | string | null: false|
 | pref    | string | null: false |

--- a/app/assets/stylesheets/sales.scss
+++ b/app/assets/stylesheets/sales.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sales controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/sales_controller.rb
+++ b/app/controllers/sales_controller.rb
@@ -1,0 +1,10 @@
+class SalesController < ApplicationController
+  def create
+    Sale.create(sale_params)
+  end
+
+  private
+  def sale_params
+    params.require(:sale).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+end

--- a/app/helpers/sales_helper.rb
+++ b/app/helpers/sales_helper.rb
@@ -1,0 +1,2 @@
+module SalesHelper
+end

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -1,6 +1,4 @@
 class Sale < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  belongs_to :user
+  belongs_to :item
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,63 +123,64 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+    <%= link_to '新規投稿商品', href="/items/new", class: "subtitle" %>
+      <ul class='item-lists'>
+        <% if @items.exists? %>
+          <% @items.each do |item| %>
+           <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <li class='list'>
+                <%= link_to item_path(item.id) do %>
+                  <div class='item-img-content'>
+                   <%= image_tag item.image, class: "item-img" %>
+                    <% if item.sale != nil %>
+                      <div class='sold-out'> %>
+                        <span>Sold Out!!</span>
+                      </div>
+                    <% end %>
+                  </div>
+                  <div class='item-info'>
+                    <h3 class='item-name'>
+                     <%= item.name %>
+                    </h3>
+                    <div class='item-price'>
+                      <span><%= item.price %>円<br>(税込み)</span>
+                      <div class='star-btn'>
+                       <%= image_tag "star.png", class:"star-icon" %>
+                       <span class='star-count'>0</span>
+                      </div>
+                   </div>
+                 </div>
+               <% end %>
+            </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+      <% else %>
+          <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <%# 商品がない場合のダミー %>
+          <%# 商品がある場合は表示されないようにしましょう %>
+          <li class='list'>
+            <%= link_to '#' do %>
+              <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  商品を出品してね！
+                </h3>
+                <div class='item-price'>
+                   <span>99999999円<br>(税込み)</span>
+                   <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+           <% end %>
+          </li>
+             <%# //商品がある場合は表示されないようにしましょう %>
+             <%# //商品がない場合のダミー %>
         <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
-    </ul>
-  </div>
+      </ul>
+    </div>
   <%# //商品一覧 %>
-</div>
+ </div>
 <% if user_signed_in? %>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
   # devise_for :addresses
   # devise_for :sales
   # devise_for :items
-  resources :items 
+  resources :items do
+    resources :sales, only: [:create]
+  end
   
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20200814081510_create_addresses.rb
+++ b/db/migrate/20200814081510_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string :post_code,  null: false
+      t.string :pref,       null: false 
+      t.string :city,           null: false
+      t.string :street,         null: false 
+      t.string :building,        default: ""
+      t.string :tel,             null: false 
+      t.integer :item_id,       null: false, foreign_key: true 
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200814100525_create_sales.rb
+++ b/db/migrate/20200814100525_create_sales.rb
@@ -1,0 +1,9 @@
+class CreateSales < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sales do |t|
+      t.integer :user_id,          null: false, foreign_key: true
+      t.integer :item_id,          null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_12_055514) do
+ActiveRecord::Schema.define(version: 2020_08_14_100525) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,18 @@ ActiveRecord::Schema.define(version: 2020_08_12_055514) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.string "pref", null: false
+    t.string "city", null: false
+    t.string "street", null: false
+    t.string "building", default: ""
+    t.string "tel", null: false
+    t.integer "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -48,6 +60,13 @@ ActiveRecord::Schema.define(version: 2020_08_12_055514) do
     t.integer "day_id", null: false
     t.integer "price", null: false
     t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "sales", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "item_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/sales.rb
+++ b/spec/factories/sales.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :sale do
+    association :item
+    association :user
+  end
+end

--- a/spec/helpers/sales_helper_spec.rb
+++ b/spec/helpers/sales_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SalesHelper. For example:
+#
+# describe SalesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SalesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/sale_spec.rb
+++ b/spec/models/sale_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Sale, type: :model do
+  before do
+    @sale = FactoryBot.build(:sale)
+  end
+  describe '商品情報の保存' do
+    it 'すべての値が正しく入力されていれば保存できること' do
+      expect(@sale).to be_valid
+    end
+    it 'user_idが空だと保存できない' do
+      @sale.user = nil
+      @sale.valid?
+      expect(@sale.errors.full_messages).to include('User must exist')
+    end
+    it 'item_idが空だと保存できない' do
+      @sale.item = nil
+      @sale.valid?
+      expect(@sale.errors.full_messages).to include('Item must exist')
+    end
+  end
+end

--- a/spec/requests/sales_request_spec.rb
+++ b/spec/requests/sales_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Sales", type: :request do
+
+end


### PR DESCRIPTION
#waht:商品一覧表示機能

#why:以下トレロです
出品された商品はトップページで一覧で表示されること。コードレビューを依頼する。LGTMが出たら完了とする。

# 実装方針
- ブランチを作成する
- 商品一覧表示機能を実装する
- プルリクエストを作成してメンターにレビューを依頼する
- LGTMをもらったらデプロイする

# 実装の条件
- 画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
- 出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、「sold out」の文字が表示されるようになっていること
- ログアウト状態でも商品一覧ページを見ることができること

# 補足情報
なし

# 注意事項
- メンターにコードレビューを依頼すること。
- コードレビューを依頼する前に、Rubocopを実行すること。
- 機能毎に、commitとpushを行うこと。"